### PR TITLE
link on README file was changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@ Guerilla Open Access Manifesto
 ==============================
 
 Guerilla Open Access Manifesto, by Aaron Swartz, in several languages.
-The manifesto can be accessed at http://openaccessmanifesto.org
+The manifesto can be accessed at https://archive.org/details/GuerillaOpenAccessManifesto

--- a/README.md
+++ b/README.md
@@ -3,3 +3,5 @@ Guerilla Open Access Manifesto
 
 Guerilla Open Access Manifesto, by Aaron Swartz, in several languages.
 The manifesto can be accessed at https://archive.org/details/GuerillaOpenAccessManifesto
+
+If you agree, feel free to fork this repo for share it :)


### PR DESCRIPTION
Hi Everton, how are you?
I found a issue on the readme file link "openaccessmanifesto.org", that is redirecting to another site, so I was changed the link for "archive.org/details/GuerillaOpenAccessManifesto"

I take this opportunity to thank you for publishing the manifesto :)
